### PR TITLE
fix: async_add_job deprecated warning

### DIFF
--- a/custom_components/npm_switches/__init__.py
+++ b/custom_components/npm_switches/__init__.py
@@ -59,8 +59,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     for platform in PLATFORMS:
         if entry.options.get(platform, True):
             coordinator.platforms.append(platform)
-            hass.async_add_job(
-                hass.config_entries.async_forward_entry_setup(entry, platform)
+            entry.async_create_task(hass(
+                hass, hass.config_entries.async_forward_entry_setup(entry, platform)
             )
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))


### PR DESCRIPTION
Stop calling deprecated async_add_job() as described [here](https://developers.home-assistant.io/blog/2024/03/13/deprecate_add_run_job/), fixes #6 