### PR TITLE
Update entity_id format to meet HA requirements

### DIFF
--- a/custom_components/npm_switches/button.py
+++ b/custom_components/npm_switches/button.py
@@ -37,8 +37,8 @@ class NpmSwitchesCertificateRenewButton(NpmSwitchesEntity, ButtonEntity):
         super().__init__(coordinator, entry)
         self.cert_id = str(certificate["id"])
         self.name = "Renew Certificate " + certificate["domain_names"][0]
-        self.entity_id = "button."+slugify(f"{entry.title}")+" Renew Cert "+str(self.cert_id)
-        self._attr_unique_id = f"{entry.entry_id} {" Renew Cert "} {self.cert_id}"
+        self.entity_id = "button."+slugify(f"{entry.title}")+"_renew_cert_"+str(self.cert_id)
+        self._attr_unique_id = f"{entry.entry_id} {"_renew_cert_"} {self.cert_id}"
         self._attr_icon = "mdi:refresh"
 
     async def async_press(self) -> None:

--- a/custom_components/npm_switches/sensor.py
+++ b/custom_components/npm_switches/sensor.py
@@ -167,8 +167,8 @@ class NpmSwitchesCertSensor(NpmSwitchesEntity, SensorEntity):
         super().__init__(coordinator, entry)
         self.cert_id = str(certificate["id"])
         self.name = "Certificate " + certificate["domain_names"][0]
-        self.entity_id = "sensor."+slugify(f"{entry.title}")+" Cert "+str(self.cert_id)
-        self._attr_unique_id = f"{entry.entry_id} {" Cert "} {self.cert_id}"
+        self.entity_id = "sensor."+slugify(f"{entry.title}")+"_cert_"+str(self.cert_id)
+        self._attr_unique_id = f"{entry.entry_id} {"_cert_"} {self.cert_id}"
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
         self._expires_on: Optional[datetime] = None
 


### PR DESCRIPTION
HA shows warnings for entity IDs with spaces, so have updated to use underscore.  These are usually generated from the name these days, so alternative is to just omit this field.